### PR TITLE
Change webpack module format to Universal Module Definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/lib
 /dist
 /node_modules
 /docs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ricado/api-client",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,9 +5,8 @@
     "author": {
         "name": "Ash Neilson"
     },
-    "main": "./dist/index.js",
-    "browser": "./dist/ricado.api.client.js",
-    "types": "./dist/index.d.ts",
+    "main": "dist/ricado.api.client.js",
+    "types": "dist/ricado.api.client.d.ts",
     "files": [
         "dist",
         "src",
@@ -28,8 +27,8 @@
         "client"
     ],
     "scripts": {
-        "clean": "rimraf dist && rimraf docs",
-        "build": "genversion --semi --es6 src/PackageVersion.js && tsc && cross-env babel src --out-dir dist && cross-env NODE_ENV=production webpack -p --config webpack.config.js",
+        "clean": "rimraf lib && rimraf dist && rimraf docs",
+        "build": "genversion --semi --es6 src/PackageVersion.js && tsc && cross-env babel src --out-dir lib && cross-env NODE_ENV=production webpack -p --config webpack.config.js",
         "docs": "jsdoc -c jsdoc.json",
         "prepublishOnly": "npm run clean && npm run build && npm run types-lint",
         "types-lint": "tsc && dtslint --localTs node_modules/typescript/lib types"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const webpack = require("webpack");
 const path = require("path");
 const packageJson = require("./package.json");
+const outputFileName = "ricado.api.client";
 
 /**
  * Bundle Typescript declaration files into a single dist/index.d.ts.
@@ -13,7 +14,7 @@ class DtsBundlePlugin {
             dts.bundle({
                 name: packageJson.name,
                 main: "types/index.d.ts",
-                out: "../dist/index.d.ts",
+                out: `../dist/${outputFileName}.d.ts`,
                 outputAsModuleFolder: false,
             });
         });
@@ -24,12 +25,12 @@ class DtsBundlePlugin {
  * Webpack Config
  */
 module.exports = {
-    entry: "./dist/index.js",
+    entry: "./lib/index.js",
     output: {
         path: path.resolve(__dirname, "dist"),
-        filename: "ricado.api.client.js",
+        filename: `${outputFileName}.js`,
         library: "RICADOGen4API",
-        libraryTarget: "var",
+        libraryTarget: "umd",
     },
     module: {},
     plugins: [


### PR DESCRIPTION
Following the recent upgrade to the JS API Client, Gen4 Apps are unable to import the webpack bundled code. This PR is to add support for Universal Module Definition. This is the most common module export format and should give us the most flexibility when importing/requiring in other JS ecosystems. 

Note: This has been tested in the browser via the <script /> tag and looks to be exposing the public API fine.