### PR TITLE
Bump `socket.io-parser` and `engine.io-client` to resolve known issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
             "version": "2.7.9",
             "license": "MIT",
             "dependencies": {
+                "engine.io-client": "3.5.4",
                 "js-base64": "^3.7.2",
                 "node-fetch": "^2.6.6",
-                "socket.io-client": "^2.4.0"
+                "socket.io-client": "^2.5.0",
+                "socket.io-parser": "3.3.5"
             },
             "devDependencies": {
                 "@babel/cli": "^7.14.5",
@@ -111,6 +113,7 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.9.tgz",
             "integrity": "sha512-5ug+SfZCpDAkVp9SFIZAzlW18rlzsOcJGaetCjkySnrXXDUw9AR8cDUm1iByTmdWM6yxX6/zycaV76w3YTF2gw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.1.0",
                 "@babel/code-frame": "^7.16.7",
@@ -1826,6 +1829,7 @@
             "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
             "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/linkify-it": "*",
                 "@types/mdurl": "*"
@@ -2090,6 +2094,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
             "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -2125,6 +2130,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -3260,9 +3266,10 @@
             }
         },
         "node_modules/engine.io-client": {
-            "version": "3.5.2",
-            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.2.tgz",
-            "integrity": "sha512-QEqIp+gJ/kMHeUun7f5Vv3bteRHppHH/FMBQX/esFj/fuYfjyUKWGMo3VCvIP/V8bE9KcjHmRZrhIz2Z9oNsDA==",
+            "version": "3.5.4",
+            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.4.tgz",
+            "integrity": "sha512-ydc8uuMMDxC5KCKNJN3zZKYJk2sgyTuTZQ7Aj1DJSsLKAcizA/PzWivw8fZMIjJVBo2CJOYzntv4FSjY/Lr//g==",
+            "license": "MIT",
             "dependencies": {
                 "component-emitter": "~1.3.0",
                 "component-inherit": "0.0.3",
@@ -3272,7 +3279,7 @@
                 "indexof": "0.0.1",
                 "parseqs": "0.0.6",
                 "parseuri": "0.0.6",
-                "ws": "~7.4.2",
+                "ws": "~7.5.10",
                 "xmlhttprequest-ssl": "~1.6.2",
                 "yeast": "0.1.2"
             }
@@ -5254,9 +5261,10 @@
             }
         },
         "node_modules/socket.io-client": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.4.0.tgz",
-            "integrity": "sha512-M6xhnKQHuuZd4Ba9vltCLT9oa+YvTsP8j9NcEiLElfIg8KeYPyhWOes6x4t+LTAC8enQbE/995AdTem2uNyKKQ==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.5.0.tgz",
+            "integrity": "sha512-lOO9clmdgssDykiOmVQQitwBAF3I6mYcQAo7hQ7AM6Ny5X7fp8hIJ3HcQs3Rjz4SoggoxA1OgrQyY8EgTbcPYw==",
+            "license": "MIT",
             "dependencies": {
                 "backo2": "1.0.2",
                 "component-bind": "1.0.0",
@@ -5280,9 +5288,10 @@
             }
         },
         "node_modules/socket.io-parser": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.2.tgz",
-            "integrity": "sha512-FJvDBuOALxdCI9qwRrO/Rfp9yfndRtc1jSgVgV8FDraihmSP/MLGD5PEuJrNfjALvcQ+vMDM/33AWOYP/JSjDg==",
+            "version": "3.3.5",
+            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.5.tgz",
+            "integrity": "sha512-pn+xG/oVnofxqteOawycpHw9QKclpNRa+Z7RW0vZmrIpkgZOVSVzBvY1YGR+p9kIEZXkeAjpHa21wRNLCZ6UAA==",
+            "license": "MIT",
             "dependencies": {
                 "component-emitter": "~1.3.0",
                 "debug": "~3.1.0",
@@ -5773,6 +5782,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.8.tgz",
             "integrity": "sha512-oz1765PN+imfz1MlZzSZPtC/tqcwsCyIYA8L47EkRnRW97ztRk83SzMiWLrnChC0vqoYxSU1fcFUDA5gV/ZiPg==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -5922,6 +5932,7 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.72.0.tgz",
             "integrity": "sha512-qmSmbspI0Qo5ld49htys8GY9XhS9CGqFoHTsOVAnjBdg0Zn79y135R+k4IR4rKK6+eKaabMhJwiVB7xw0SJu5w==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.3",
                 "@types/estree": "^0.0.51",
@@ -6038,6 +6049,7 @@
             "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.2.tgz",
             "integrity": "sha512-m3/AACnBBzK/kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^1.1.1",
@@ -6194,9 +6206,10 @@
             "dev": true
         },
         "node_modules/ws": {
-            "version": "7.4.6",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-            "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+            "version": "7.5.10",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=8.3.0"
             },
@@ -6377,6 +6390,7 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.9.tgz",
             "integrity": "sha512-5ug+SfZCpDAkVp9SFIZAzlW18rlzsOcJGaetCjkySnrXXDUw9AR8cDUm1iByTmdWM6yxX6/zycaV76w3YTF2gw==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@ampproject/remapping": "^2.1.0",
                 "@babel/code-frame": "^7.16.7",
@@ -7620,6 +7634,7 @@
             "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
             "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@types/linkify-it": "*",
                 "@types/mdurl": "*"
@@ -7869,7 +7884,8 @@
             "version": "8.4.1",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
             "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "acorn-import-assertions": {
             "version": "1.7.6",
@@ -7894,6 +7910,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -8834,9 +8851,9 @@
             }
         },
         "engine.io-client": {
-            "version": "3.5.2",
-            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.2.tgz",
-            "integrity": "sha512-QEqIp+gJ/kMHeUun7f5Vv3bteRHppHH/FMBQX/esFj/fuYfjyUKWGMo3VCvIP/V8bE9KcjHmRZrhIz2Z9oNsDA==",
+            "version": "3.5.4",
+            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.4.tgz",
+            "integrity": "sha512-ydc8uuMMDxC5KCKNJN3zZKYJk2sgyTuTZQ7Aj1DJSsLKAcizA/PzWivw8fZMIjJVBo2CJOYzntv4FSjY/Lr//g==",
             "requires": {
                 "component-emitter": "~1.3.0",
                 "component-inherit": "0.0.3",
@@ -8846,7 +8863,7 @@
                 "indexof": "0.0.1",
                 "parseqs": "0.0.6",
                 "parseuri": "0.0.6",
-                "ws": "~7.4.2",
+                "ws": "~7.5.10",
                 "xmlhttprequest-ssl": "~1.6.2",
                 "yeast": "0.1.2"
             },
@@ -10438,9 +10455,9 @@
             "dev": true
         },
         "socket.io-client": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.4.0.tgz",
-            "integrity": "sha512-M6xhnKQHuuZd4Ba9vltCLT9oa+YvTsP8j9NcEiLElfIg8KeYPyhWOes6x4t+LTAC8enQbE/995AdTem2uNyKKQ==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.5.0.tgz",
+            "integrity": "sha512-lOO9clmdgssDykiOmVQQitwBAF3I6mYcQAo7hQ7AM6Ny5X7fp8hIJ3HcQs3Rjz4SoggoxA1OgrQyY8EgTbcPYw==",
             "requires": {
                 "backo2": "1.0.2",
                 "component-bind": "1.0.0",
@@ -10466,9 +10483,9 @@
             }
         },
         "socket.io-parser": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.2.tgz",
-            "integrity": "sha512-FJvDBuOALxdCI9qwRrO/Rfp9yfndRtc1jSgVgV8FDraihmSP/MLGD5PEuJrNfjALvcQ+vMDM/33AWOYP/JSjDg==",
+            "version": "3.3.5",
+            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.5.tgz",
+            "integrity": "sha512-pn+xG/oVnofxqteOawycpHw9QKclpNRa+Z7RW0vZmrIpkgZOVSVzBvY1YGR+p9kIEZXkeAjpHa21wRNLCZ6UAA==",
             "requires": {
                 "component-emitter": "~1.3.0",
                 "debug": "~3.1.0",
@@ -10882,7 +10899,8 @@
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.8.tgz",
             "integrity": "sha512-oz1765PN+imfz1MlZzSZPtC/tqcwsCyIYA8L47EkRnRW97ztRk83SzMiWLrnChC0vqoYxSU1fcFUDA5gV/ZiPg==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "uc.micro": {
             "version": "1.0.6",
@@ -11001,6 +11019,7 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.72.0.tgz",
             "integrity": "sha512-qmSmbspI0Qo5ld49htys8GY9XhS9CGqFoHTsOVAnjBdg0Zn79y135R+k4IR4rKK6+eKaabMhJwiVB7xw0SJu5w==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@types/eslint-scope": "^3.7.3",
                 "@types/estree": "^0.0.51",
@@ -11083,6 +11102,7 @@
             "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.2.tgz",
             "integrity": "sha512-m3/AACnBBzK/kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^1.1.1",
@@ -11199,9 +11219,9 @@
             "dev": true
         },
         "ws": {
-            "version": "7.4.6",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-            "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+            "version": "7.5.10",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
             "requires": {}
         },
         "xmlcreate": {

--- a/package.json
+++ b/package.json
@@ -41,9 +41,11 @@
         "analyze-webpack": "npm run generate-version-file && npm run babel && cross-env NODE_ENV=production webpack --profile --json > stats.json && webpack-bundle-analyzer ./stats.json"
     },
     "dependencies": {
+        "engine.io-client": "3.5.4",
         "js-base64": "^3.7.2",
         "node-fetch": "^2.6.6",
-        "socket.io-client": "^2.4.0"
+        "socket.io-client": "^2.5.0",
+        "socket.io-parser": "3.3.5"
     },
     "devDependencies": {
         "@babel/cli": "^7.14.5",


### PR DESCRIPTION
- Bumps `socket.io-parser` to 3.3.5 which resolves a security advisory on this package.
- Bumps `engine.io-client` to 3.5.4 which resolves a security advisory on the `ws` package.